### PR TITLE
add Link component to handle linking to new components in the router

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "react"],
+  "plugins": ["transform-class-properties"]
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ The `Router` class is a React component that accepts no props, but can have chil
 
 The `Router` should be placed at the application root.
 
+#### `<Link />`
+
+The `Link` component is a convient way to link to an external website or a new component wihtout manually calling `goTo`. Accepted properties are:
+
+```js
+Link.propTypes = {
+  href: PropTypes.string,  // to direct to an external site
+  component: PropTypes.instanceOf(React.Component),  // to put a new component on the stack
+  componentProps: PropTypes.object,
+  className: PropTypes.string,
+  id: PropTypes.string,
+  onClick: PropTypes.func,
+}
+```
+
+**NOTE:** There is a "whitelist" of sorts for props, only `data-` props will be propogated down to the child link component.
+
 #### `goTo(component, props)`
 
 The `goTo` method accepts two arguments, a component and props. These must be separated so they can be kept in history without having to keep all components rendered at once.
@@ -34,10 +51,17 @@ Route Lite has a simple API that makes it easy to get started with no config. No
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Router, { goTo, goBack } from 'route-lite';
+import Router, { Link, goBack } from 'route-lite';
 
 const A = () => {
-  return <div onClick={() => goTo(B, {text: "Component B"})}>Component A</div>
+  return (
+    <Link
+      component={B}
+      componentProps={{text: "Component B"}}
+    >
+      Component A
+    </Link>
+  );
 }
 
 const B = ({text}) => {

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Links handle clicks properly 1`] = `
+<a
+  className=""
+  href="http://google.com"
+  id=""
+  onClick={[Function]}
+>
+  Click here!
+</a>
+`;
+
+exports[`Links handle clicks properly 2`] = `
+<div>
+  Next Component
+</div>
+`;
+
+exports[`Renders plain links properly 1`] = `
+<a
+  className="my-class"
+  data-prop="42"
+  href="http://google.com"
+  id="the-link"
+  onClick={[Function]}
+>
+  Click here!
+</a>
+`;
+
 exports[`Router renders default component only when nothing is on the stack 1`] = `
 <div>
   Hello, world!

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import Router, { goTo, goBack } from '../index';
+import Router, { goTo, goBack, Link } from '../index';
 
 const A = () => <div>Component A</div>;
 
@@ -18,6 +18,44 @@ test('Router renders default component only when nothing is on the stack', () =>
   expect(tree).toMatchSnapshot();
 
   goBack();
+  tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Renders plain links properly', () => {
+  expect(
+    renderer
+      .create(
+        <Link
+          data-prop="42"
+          href="http://google.com"
+          className="my-class"
+          id="the-link"
+        >
+          Click here!
+        </Link>
+      )
+      .toJSON()
+  ).toMatchSnapshot();
+});
+
+test('Links handle clicks properly', () => {
+  const Next = () => <div>Next Component</div>;
+  const component = renderer.create(
+    <Router>
+      <Link
+        href="http://google.com"
+        component={Next}
+        componentProps={{ a: 'b' }}
+      >
+        Click here!
+      </Link>
+    </Router>
+  );
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+
+  tree.props.onClick(new Event('click'));
   tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/index.js
+++ b/index.js
@@ -27,6 +27,18 @@ export class Link extends React.PureComponent {
     super(props);
   }
 
+  onClick = evt => {
+    evt.preventDefault();
+    if (this.props.component) {
+      goTo(this.props.component, this.props.componentProps || {});
+    } else if (this.props.href) {
+      open(this.props.href);
+    }
+    if (typeof this.props.onClick === 'function') {
+      this.props.onClick(evt);
+    }
+  };
+
   render() {
     const dataProps = {};
     Object.keys(this.props).forEach(key => {
@@ -35,22 +47,13 @@ export class Link extends React.PureComponent {
       }
     });
 
-    const onClick = evt => {
-      evt.preventDefault();
-      if (this.props.component) {
-        goTo(this.props.component, this.props.componentProps || {});
-      } else if (this.props.href) {
-        open(this.props.href);
-      }
-    };
-
     return (
       <a
         href={this.props.href ? this.props.href : ''}
         className={this.props.className}
         id={this.props.id}
         {...dataProps}
-        onClick={onClick}
+        onClick={this.onClick}
       >
         {this.props.children}
       </a>

--- a/index.js
+++ b/index.js
@@ -22,6 +22,47 @@ function goBack() {
   component && component.forceUpdate();
 }
 
+export class Link extends React.PureComponent {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const dataProps = {};
+    Object.keys(this.props).forEach(key => {
+      if (key.match('data')) {
+        dataProps[key] = this.props[key];
+      }
+    });
+
+    const onClick = evt => {
+      evt.preventDefault();
+      if (this.props.component) {
+        goTo(this.props.component, this.props.componentProps || {});
+      } else if (this.props.href) {
+        open(this.props.href);
+      }
+    };
+
+    return (
+      <a
+        href={this.props.href ? this.props.href : ''}
+        className={this.props.className}
+        id={this.props.id}
+        {...dataProps}
+        onClick={onClick}
+      >
+        {this.props.children}
+      </a>
+    );
+  }
+}
+
+Link.defaultProps = {
+  className: '',
+  id: ''
+};
+
 export default class Router extends React.Component {
   constructor() {
     super();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "route-lite",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -495,6 +495,12 @@
       "integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
       "dev": true
     },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
@@ -512,6 +518,18 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
@@ -3147,11 +3165,6 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
-    },
-    "immutable": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
-      "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI="
     },
     "imurmurhash": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-cli": "^6.26.0",
     "babel-jest": "^21.2.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "jest": "^21.2.1",


### PR DESCRIPTION
provides an easy way to link to new components without manually calling `goTo`